### PR TITLE
added delete endpoint to each resource #io-3108 Code Review

### DIFF
--- a/api/endpoints/agreement.md
+++ b/api/endpoints/agreement.md
@@ -37,6 +37,11 @@ To update a Agreement send JSON with the id and updated value for one or more of
     
     [Agreement][]
 
+### Remove an Agreement [DELETE]
++ Parameters
+    + id (string) ... ID of the Agreement
++ Response 200
+
 ## Agreement Collection [/agreements]
 Collection of all Agreements.
 
@@ -74,3 +79,5 @@ The field `type` is required in order to create a new agreement.
 + Response 201
 
     [Agreement][]
+
+

--- a/api/endpoints/asset.md
+++ b/api/endpoints/asset.md
@@ -49,6 +49,11 @@ To update a Asset send JSON with updated value for one or more of the attributes
     
     [Asset][]
 
+### Remove an Asset [DELETE]
++ Parameters
+    + id (string) ... ID of the Asset
++ Response 200
+
 ## Asset Collection [/assets{?search,searchSerialNumber,typeId,buildingId,floorId,roomId,owner}]
 Collection of all Assets.
 

--- a/api/endpoints/building.md
+++ b/api/endpoints/building.md
@@ -40,6 +40,12 @@ To update a Building send JSON with updated value for one or more of the attribu
     
     [Building][]
 
+### Remove a Building [DELETE]
++ Parameters
+    + id (string) ... ID of the Building
++ Response 200
+
+
 ## Building Collection [/buildings{?includeReservable,includeNonReservable,locationSearch,nearLatitude,nearLongitude}]
 Collection of all Buildings.
 

--- a/api/endpoints/contact.md
+++ b/api/endpoints/contact.md
@@ -37,6 +37,11 @@ To update a Contact send JSON with the id and updated value for one or more of t
     
     [Contact][]
 
+### Remove a Contact [DELETE]
++ Parameters
+    + id (string) ... ID of the Contact
++ Response 200
+
 ## Contact Collection [/contacts]
 Collection of all Contacts.
 

--- a/api/endpoints/country.md
+++ b/api/endpoints/country.md
@@ -29,6 +29,11 @@ Countries cannot be modified.
 
 + Response 500
 
+### Remove a Country [DELETE]
++ Parameters
+    + id (string) ... ID of the Country
++ Response 200
+
 ## Country Collection [/countries]
 Collection of all Countries.
 

--- a/api/endpoints/floor.md
+++ b/api/endpoints/floor.md
@@ -38,6 +38,11 @@ To update a Floor send JSON with updated value for one or more of the attributes
     
     [Floor][]
 
+### Remove a Floor [DELETE]
++ Parameters
+    + id (string) ... ID of the Floor
++ Response 200
+
 ## Floor Collection [/floors{?buildingId}]
 Collection of all Floors.
 

--- a/api/endpoints/maintenance.md
+++ b/api/endpoints/maintenance.md
@@ -61,6 +61,11 @@ To update a Request send JSON with updated value for one or more of the attribut
     
     [Request][]
 
+### Remove a Request [DELETE]
++ Parameters
+    + id (string) ... ID of the Request
++ Response 200
+
 ### Requests Collection [/maintenance/requests{?priority,assigned,pastDue}]
 Collection of all Requests.
 

--- a/api/endpoints/reservation.md
+++ b/api/endpoints/reservation.md
@@ -44,6 +44,11 @@ To update a Reservation send JSON with updated value for one or more of the attr
     
     [Reservation][]
 
+### Remove a Reservation [DELETE]
++ Parameters
+    + id (string) ... ID of the Reservation
++ Response 200
+
 ## Reservation Collection [/reservations{?includeCancelled,includePastReservations,includeNonCancelled,showOnlyMyReservations}]
 Collection of all Reservations.
 

--- a/api/endpoints/room.md
+++ b/api/endpoints/room.md
@@ -40,6 +40,11 @@ To update a Room send JSON with updated value for one or more of the attributes.
     
     [Room][]
 
+### Remove a Reservation [DELETE]
++ Parameters
+    + id (string) ... ID of the Reservation
++ Response 200
+
 ## Room Collection [/rooms{?includeReservable,includeNonReservable,locationSearch,nearLatitude,nearLongitude,startDate,endDate,numberOfPeople,search,buildingId,floorId,type}]
 Collection of all Rooms.
 

--- a/api/endpoints/user.md
+++ b/api/endpoints/user.md
@@ -66,6 +66,11 @@ To update a User send JSON with updated value for one or more of the attributes.
     
     [User][]
 
+### Remove a User [DELETE]
++ Parameters
+    + id (string) ... ID of the User
++ Response 200
+
 ## User Collection [/users{?search,centerId,role}]
 Collection of all Users.
 


### PR DESCRIPTION
@kentongray the ticket only asked for the delete info to be added to the maintenance endpoint but I noticed that the Delete method was added to YogaRester so I changed the docs for each endpoint.  If thats not what you want let me know, if its cool I can merge.
